### PR TITLE
Initial implementation of basic attributes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,5 @@
 source 'https://supermarket.chef.io'
 
-
 cookbook 'kitchen-ohai' # required for ec2
 
 metadata

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,6 @@
+default['smbios'] # auto-vivify the root SMBIOS attribute
+
+unless ::Chef::Config[:smbios_info_disabled]
+  # Provide SMBIOS info
+  automatic_attrs['smbios'] = ::SMBIOS.info(node)
+end

--- a/libraries/_chefspec_patch.rb
+++ b/libraries/_chefspec_patch.rb
@@ -1,0 +1,8 @@
+if defined?(::ChefSpec)
+  require 'chef/config'
+
+  if ::Chef::Config[:smbios_info_disabled].nil?
+    ::Chef::Log.warn '[SMBIOS] Do not retrieve SMBIOS info in ChefSpec context'
+    ::Chef::Config[:smbios_info_disabled] = true
+  end
+end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,0 +1,43 @@
+module SMBIOS
+  SYSFS_DMI_ID = '/sys/devices/virtual/dmi/id/'.freeze unless constants.include?(:SYSFS_DMI_ID)
+
+  def self.windows_info
+    wmi = ::WmiLite::Wmi.new
+    system_info = wmi.first_of('WIN32_ComputerSystem')
+    bios_info = wmi.first_of('WIN32_Bios')
+    ::Mash.new(
+      bios:    ::Mash.new(
+        vendor:  bios_info['Manufacturer'].to_s.strip,
+        version: bios_info['SMBIOSBIOSVersion'].to_s.strip,
+      ),
+      product: ::Mash.new(
+        serial: bios_info['SerialNumber'].to_s.strip,
+        name:   system_info['Model'].to_s.strip,
+      ),
+    )
+  end
+
+  def self.linux_info
+    info = ::Mash.new
+    { product: %w[serial name], bios: %w[vendor version] }.each do |type, keys|
+      info[type] ||= ::Mash.new
+      keys.each do |key|
+        path = ::File.join(SYSFS_DMI_ID, "#{type}_#{key}")
+        info[type][key] = ::File.read(path).strip if ::File.exist?(path)
+      end
+    end
+    info
+  end
+
+  def self.info(node)
+    case node['os']
+    when 'linux'
+      linux_info
+    when 'windows'
+      windows_info
+    else
+      ::Chef::Log.warn "[SMBIOS] #{node['os']} is not a supported Operating System."
+      ::Mash.new
+    end
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -8,11 +8,11 @@
 require 'spec_helper'
 
 describe 'smbios::default' do
-  context 'When all attributes are default, on centos 6.7' do
+  context 'When all attributes are default, on centos 6.9' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version:  '6.7',
+        version:  '6.9',
       )
       runner.converge(described_recipe)
     end
@@ -21,11 +21,11 @@ describe 'smbios::default' do
       expect { chef_run }.to_not raise_error
     end
   end
-  context 'When all attributes are default, on centos 7.2.1511' do
+  context 'When all attributes are default, on centos 7.4.1708' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version:  '7.2.1511',
+        version:  '7.4.1708',
       )
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
Provides several basic attributes for Linux & Windows:
- product name
- product serial
- bios vendor
- bios version

One can disable the fetching of above attributes using Chef config.
Just set 'smbios_info_disabled' to a truthy value.

N.B.: Chefspec tests are not validation anything at the moment.