### PR TITLE
Do not fail if bios.date is not discovered

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -30,7 +30,7 @@ module SMBIOS
       end
     end
     # Format bios date to ISO 8601
-    info['bios']['date'].gsub!(%r{(\d+)/(\d+)/(\d+).*}, '\3-\1-\2')
+    info.dig('bios', 'date')&.gsub!(%r{(\d+)/(\d+)/(\d+).*}, '\3-\1-\2')
     info
   end
 


### PR DESCRIPTION
On specific context the bios date is not available, Chef should not fail.